### PR TITLE
removehead() bug fixed

### DIFF
--- a/linkedlist.cpp
+++ b/linkedlist.cpp
@@ -76,6 +76,14 @@ void linkedlist::addtail(int n){
 	 node *temp = head;
 	 node *prev = 0;
 	 
+	 //On empty List do nothing
+	 
+	 if(head == 0)
+	 {
+	 	cout << "Empty List" <<"\n" ;
+	 	return ;
+	 }
+	 
 	 if(head->element  ==n ){																// deleting head
 		removehead();
 	}


### PR DESCRIPTION
On Empty list original method use to fail (segmentation fault).

So on empty list there is possibly nothing to search so the program gracefully exists